### PR TITLE
update name

### DIFF
--- a/bicep/main.bicep
+++ b/bicep/main.bicep
@@ -14,7 +14,7 @@ param resourceNameSuffix string = uniqueString(resourceGroup().id)
 
 // Define the names for resources.
 var appServiceAppName = 'toy-website-${resourceNameSuffix}'
-var appServicePlanName = 'toy-website'
+var appServicePlanName = 'toy-website2'
 var storageAccountName = 'mystorage${resourceNameSuffix}'
 
 // Define the SKUs for each component based on the environment type.


### PR DESCRIPTION
This pull request to the `bicep/main.bicep` file updates the value of the `appServicePlanName` variable from `toy-website` to `toy-website2` to align with the updated naming convention for the app service plan.

Main change:

* <a href="diffhunk://#diff-d8f9d747f5da453065bdd73b951ef738eb7c0922dcdb0e2e4b79a6c1aa409650L17-R17">`bicep/main.bicep`</a>: Updated the value of the `appServicePlanName` variable from `toy-website` to `toy-website2`.