### PR TITLE
Rename app service plan variable for consistency in naming convention

### DIFF
--- a/bicep/main.bicep
+++ b/bicep/main.bicep
@@ -14,7 +14,7 @@ param resourceNameSuffix string = uniqueString(resourceGroup().id)
 
 // Define the names for resources.
 var appServiceAppName = 'toy-website-${resourceNameSuffix}'
-var appServicePlanName = 'toy-website'
+var appServicePlanName = 'toywebsite'
 var storageAccountName = 'mystorage${resourceNameSuffix}'
 
 // Define the SKUs for each component based on the environment type.


### PR DESCRIPTION
This pull request includes a small change to the `bicep/main.bicep` file. The change modifies the `appServicePlanName` variable to remove the hyphen for consistency.

* [`bicep/main.bicep`](diffhunk://#diff-d8f9d747f5da453065bdd73b951ef738eb7c0922dcdb0e2e4b79a6c1aa409650L17-R17): Changed `appServicePlanName` from 'toy-website' to 'toywebsite' for consistency.